### PR TITLE
Fix assert in wasm-hello example

### DIFF
--- a/src/chapters/examples/wasm-hello-example/main.cpp
+++ b/src/chapters/examples/wasm-hello-example/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char const *argv[]) {
 void hello_cb(rlbox_sandbox_mylib& _, tainted_mylib<const char*> str) {
   auto checked_string =
     str.copy_and_verify_string([](unique_ptr<char[]> val) {
-        release_assert(val != nullptr && strlen(val.get()) < 1024);
+        release_assert(val != nullptr && strlen(val.get()) < 1024, "val is null or greater than 1024\n");
         return move(val);
     });
   printf("hello_cb: %s\n", checked_string.get());


### PR DESCRIPTION
The previous example was missing the second argument, causing the build to fail.